### PR TITLE
Add support for GTM custom environments

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -19,6 +19,17 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "benyap",
+      "name": "Ben Yap",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/19235373?v=4",
+      "profile": "https://benyap.com",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ const App = () => {
 }
 ```
 
+### Use a GTM custom environment
+
+```typescript jsx
+import { useEffect } from 'react'
+import useGTM from '@elgorditosalsero/react-gtm-hook'
+
+const App = () => {
+  const { init } = useGTM()
+  const gtmParams = {
+    id: 'GTM-ID',
+    environment: {
+      gtm_auth: 'my-auth-token',
+      gtm_preview: 'preview-id'
+    }
+  }
+
+  useEffect(() => init(gtmParams), [])
+
+  return <p>My awesome app</p>
+}
+```
+
+_To find the `gtm_auth` and `gtm_preview` values for your custom GTM environment, go to Admin > Your Container > Environments > Your Environment > Actions > Get Snippet in your Google Tag Manager console. You will find the values you need embedded in the snippet._
+
 ### Sending data to GTM
 
 ```typescript jsx
@@ -125,11 +149,12 @@ const MyAwesomeComp = () => {
 
 ### Init
 
-| Name          | Type     | Required | Info                                                                              |
-| ------------- | -------- | -------- | --------------------------------------------------------------------------------- |
-| id            | `String` | **YES**  | The container ID from the Tag Manager, it looks like: `GMT-0T0TTT`                |
-| dataLayer     | `Object` | **NO**   | Custom values for the dataLayer, like `{'my-init-prop': 'value'}`                 |
-| dataLayerName | `String` | **NO**   | Custom name for the dataLayer, if not passed, it will be the default: `dataLayer` |
+| Name          | Type     | Required | Info                                                                                |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------- |
+| id            | `String` | **YES**  | The container ID from the Tag Manager, it looks like: `GMT-0T0TTT`                  |
+| dataLayer     | `Object` | **NO**   | Custom values for the dataLayer, like `{'my-init-prop': 'value'}`                   |
+| dataLayerName | `String` | **NO**   | Custom name for the dataLayer, if not passed, it will be the default: `dataLayer`   |
+| environment   | `Object` | **NO**   | Provide the `gtm_auth` and `gtm_preview` parameters to use a custom GTM environment |
 
 ### SentDataToGTM
 
@@ -144,7 +169,9 @@ const MyAwesomeComp = () => {
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -161,6 +188,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -144,9 +144,7 @@ const MyAwesomeComp = () => {
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
-
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -157,12 +155,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://www.linkedin.com/in/guidoporcaro/"><img src="https://avatars2.githubusercontent.com/u/65770455?v=4" width="100px;" alt=""/><br /><sub><b>Guido Porcaro</b></sub></a><br /><a href="https://github.com/elgorditosalsero/react-gtm-hook/commits?author=elgorditosalsero" title="Code">💻</a> <a href="https://github.com/elgorditosalsero/react-gtm-hook/commits?author=elgorditosalsero" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://benyap.com"><img src="https://avatars3.githubusercontent.com/u/19235373?v=4" width="100px;" alt=""/><br /><sub><b>Ben Yap</b></sub></a><br /><a href="https://github.com/elgorditosalsero/react-gtm-hook/commits?author=benyap" title="Code">💻</a> <a href="https://github.com/elgorditosalsero/react-gtm-hook/commits?author=benyap" title="Documentation">📖</a> <a href="https://github.com/elgorditosalsero/react-gtm-hook/commits?author=benyap" title="Tests">⚠️</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,13 +25,16 @@ export default function useGTM(): IUseGTM {
   const [dataLayerState, setDataLayerState] = useState<ISnippetsParams>({
     dataLayer: undefined,
     dataLayerName: 'dataLayer',
+    environment: undefined,
     id: ''
   })
 
   const init = useCallback((snippetParams: ISnippetsParams): void => setDataLayerState(snippetParams), [])
 
   const sendDataToGTM = useCallback(
-    (data: Object): void => sendToGTM({ data, dataLayerName: dataLayerState.dataLayerName! }),
+    (data: Object): void => {
+      sendToGTM({ data, dataLayerName: dataLayerState.dataLayerName! })
+    },
     [dataLayerState]
   )
 
@@ -40,6 +43,7 @@ export default function useGTM(): IUseGTM {
       initGTM({
         dataLayer: dataLayerState.dataLayer,
         dataLayerName: dataLayerState.dataLayerName,
+        environment: dataLayerState.environment,
         id: dataLayerState.id
       })
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,14 @@ export default function useGTM(): IUseGTM {
     id: ''
   })
 
-  const init = useCallback((snippetParams: ISnippetsParams): void => setDataLayerState(snippetParams), [])
+  const init = useCallback(
+    (snippetParams: ISnippetsParams): void =>
+      setDataLayerState(state => ({
+        ...state,
+        ...snippetParams
+      })),
+    [setDataLayerState]
+  )
 
   const sendDataToGTM = useCallback(
     (data: Object): void => {

--- a/src/models/GoogleTagManager.ts
+++ b/src/models/GoogleTagManager.ts
@@ -16,11 +16,27 @@ export type ISnippets = {
 }
 
 /**
+ * The variables required to use a GTM custom environment
+ */
+export type ICustomEnvironment = {
+  /**
+   * For the `gtm_auth` parameter.
+   */
+  gtm_auth: string
+
+  /**
+   * For the `gtm_preview` parameter.
+   */
+  gtm_preview: string
+}
+
+/**
  * The shape of the GTM Snippets params
  */
 export type ISnippetsParams = {
   dataLayer?: Pick<IDataLayer, 'dataLayer'>['dataLayer']
   dataLayerName?: Pick<IDataLayer, 'dataLayerName'>['dataLayerName']
+  environment?: ICustomEnvironment
   id: string
 }
 

--- a/src/models/GoogleTagManager.ts
+++ b/src/models/GoogleTagManager.ts
@@ -18,7 +18,7 @@ export type ISnippets = {
 /**
  * The variables required to use a GTM custom environment
  */
-export type ICustomEnvironment = {
+export type ICustomEnvironmentParams = {
   /**
    * For the `gtm_auth` parameter.
    */
@@ -36,7 +36,7 @@ export type ICustomEnvironment = {
 export type ISnippetsParams = {
   dataLayer?: Pick<IDataLayer, 'dataLayer'>['dataLayer']
   dataLayerName?: Pick<IDataLayer, 'dataLayerName'>['dataLayerName']
-  environment?: ICustomEnvironment
+  environment?: ICustomEnvironmentParams
   id: string
 }
 

--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -50,8 +50,8 @@ export const initGTM = ({ dataLayer, dataLayerName, environment, id }: ISnippets
   const script = gtm.getScript()
   const noScript = gtm.getNoScript()
 
-  if (dataLayer) document.head.insertBefore(dataLayerScript, document.head.childNodes[0])
-  document.head.insertBefore(script, dataLayer ? document.head.childNodes[0].nextSibling : document.head.childNodes[0])
+  document.head.insertBefore(script, document.head.childNodes[0])
+  document.head.insertBefore(dataLayerScript, document.head.childNodes[0])
   document.body.insertBefore(noScript, document.body.childNodes[0])
 }
 

--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -6,22 +6,22 @@ import { ISendToGTM, ISetupGTM, ISnippetsParams } from 'models/GoogleTagManager'
  * @param params - The snippets params
  */
 const setupGTM = (params: ISnippetsParams): ISetupGTM => {
+  const getDataLayerScript = (): HTMLElement => {
+    const dataLayerScript = document.createElement('script')
+    dataLayerScript.innerHTML = getDataLayerSnippet(params.dataLayer, params.dataLayerName)
+    return dataLayerScript
+  }
+
   const getNoScript = (): HTMLElement => {
     const noScript = document.createElement('noscript')
-    noScript.innerHTML = getIframeSnippet(params.id)
+    noScript.innerHTML = getIframeSnippet(params.id, params.environment)
     return noScript
   }
 
   const getScript = (): HTMLElement => {
     const script = document.createElement('script')
-    script.innerHTML = getGTMScript(params.dataLayerName, params.id)
+    script.innerHTML = getGTMScript(params.dataLayerName, params.id, params.environment)
     return script
-  }
-
-  const getDataLayerScript = (): HTMLElement => {
-    const dataLayerScript = document.createElement('script')
-    dataLayerScript.innerHTML = getDataLayerSnippet(params.dataLayer, params.dataLayerName)
-    return dataLayerScript
   }
 
   return {
@@ -35,13 +35,14 @@ const setupGTM = (params: ISnippetsParams): ISetupGTM => {
  * Function to init the GTM
  * @param dataLayer - The dataLayer
  * @param dataLayerName - The dataLayer name
- * @param events - The events to send on init
+ * @param environment - Specify the custom environment to use
  * @param id - The ID of the GTM
  */
-export const initGTM = ({ dataLayer, dataLayerName, id }: ISnippetsParams): void => {
+export const initGTM = ({ dataLayer, dataLayerName, environment, id }: ISnippetsParams): void => {
   const gtm = setupGTM({
     dataLayer,
     dataLayerName,
+    environment,
     id
   })
 

--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -13,27 +13,42 @@ export const getDataLayerSnippet = (
 
 /**
  * Function to get the Iframe snippet
+ * @param environment - The parameters to use a custom environment
  * @param id - The id of the container
  */
-export const getIframeSnippet = (id: Pick<ISnippetsParams, 'id'>['id']) =>
-  `
-    <iframe src="https://www.googletagmanager.com/ns.html?id=${id}$&gtm_cookies_win=x" 
-        height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>
-  `
+export const getIframeSnippet = (
+  id: Pick<ISnippetsParams, 'id'>['id'],
+  environment?: Pick<ISnippetsParams, 'environment'>['environment']
+) => {
+  let params = ``
+  if (environment) {
+    const { gtm_auth, gtm_preview } = environment
+    params = `&gtm_auth=${gtm_auth}&gtm_preview=${gtm_preview}&gtm_cookies_win=x`
+  }
+  return `<iframe src="https://www.googletagmanager.com/ns.html?id=${id}${params}" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
+}
 
 /**
  * Function to get the GTM script
  * @param dataLayerName - The name of the dataLayer
+ * @param environment - The parameters to use a custom environment
  * @param id - The id of the container
  */
 export const getGTMScript = (
   dataLayerName: Pick<ISnippetsParams, 'dataLayerName'>['dataLayerName'],
-  id: Pick<ISnippetsParams, 'id'>['id']
-) =>
-  `
+  id: Pick<ISnippetsParams, 'id'>['id'],
+  environment?: Pick<ISnippetsParams, 'environment'>['environment']
+) => {
+  let params = ``
+  if (environment) {
+    const { gtm_auth, gtm_preview } = environment
+    params = `+"&gtm_auth=${gtm_auth}&gtm_preview=${gtm_preview}&gtm_cookies_win=x"`
+  }
+  return `
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl${params};f.parentNode.insertBefore(j,f);
     })(window,document,'script','${dataLayerName}','${id}');
   `
+}

--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -7,9 +7,9 @@ import { IDataLayer, ISnippets, ISnippetsParams } from 'models/GoogleTagManager'
  */
 export const getDataLayerSnippet = (
   dataLayer: Pick<IDataLayer, 'dataLayer'>['dataLayer'],
-  dataLayerName?: Pick<IDataLayer, 'dataLayerName'>['dataLayerName']
+  dataLayerName: Pick<IDataLayer, 'dataLayerName'>['dataLayerName'] = 'dataLayer'
 ): Pick<ISnippets, 'gtmDataLayer'>['gtmDataLayer'] =>
-  typeof dataLayer === 'undefined' ? 'dataLayer = []' : `${dataLayerName} = [${JSON.stringify(dataLayer)}]`
+  `${dataLayerName} = [${typeof dataLayer === 'undefined' ? '' : JSON.stringify(dataLayer)}]`
 
 /**
  * Function to get the Iframe snippet

--- a/test/snippets.test.ts
+++ b/test/snippets.test.ts
@@ -46,6 +46,29 @@ describe('Suite of snippets functions', () => {
 
       expect(gtmSnippet).toContain(`${customDataLayerName}`)
       expect(gtmSnippet).toContain(`${params.id}`)
+      expect(gtmSnippet).not.toContain('gtm_auth')
+      expect(gtmSnippet).not.toContain('gtm_preview')
+    })
+
+    it('should return the script with the default dataLayerName and custom environment auth', () => {
+      const customDataLayerName = 'custonDL'
+      params = {
+        ...params,
+        dataLayerName: customDataLayerName,
+        environment: {
+          gtm_auth: 'custom_environment_auth',
+          gtm_preview: 'custom_environment_preview'
+        }
+      }
+
+      const gtmSnippet = getGTMScript(params.dataLayerName, params.id, params.environment)
+
+      expect(gtmSnippet).toContain(`${customDataLayerName}`)
+      expect(gtmSnippet).toContain(`${params.id}`)
+      expect(gtmSnippet).toContain('gtm_auth')
+      expect(gtmSnippet).toContain('gtm_preview')
+      expect(gtmSnippet).toContain(params.environment!.gtm_auth)
+      expect(gtmSnippet).toContain(params.environment!.gtm_preview)
     })
   })
 
@@ -56,10 +79,30 @@ describe('Suite of snippets functions', () => {
       params = { id: 'GTM-iframe' }
     })
 
-    it('should return the iframe snippet with the passed it', () => {
+    it('should return the iframe snippet with the passed id', () => {
       const iframeSnippet = getIframeSnippet(params.id)
 
       expect(iframeSnippet).toContain(`${params.id}`)
+      expect(iframeSnippet).not.toContain('gtm_auth')
+      expect(iframeSnippet).not.toContain('gtm_preview')
+    })
+
+    it('should return the iframe snippet with the passed id and custom environment auth', () => {
+      params = {
+        ...params,
+        environment: {
+          gtm_auth: 'custom_environment_auth',
+          gtm_preview: 'custom_environment_preview'
+        }
+      }
+
+      const iframeSnippet = getIframeSnippet(params.id, params.environment)
+
+      expect(iframeSnippet).toContain(`${params.id}`)
+      expect(iframeSnippet).toContain('gtm_auth')
+      expect(iframeSnippet).toContain('gtm_preview')
+      expect(iframeSnippet).toContain(params.environment!.gtm_auth)
+      expect(iframeSnippet).toContain(params.environment!.gtm_preview)
     })
   })
 })

--- a/test/useGTM.test.tsx
+++ b/test/useGTM.test.tsx
@@ -5,19 +5,34 @@ import useGTM from '../src'
 import { ISnippetsParams } from '../src/models/GoogleTagManager'
 
 describe('Suite of useGTM Hook', () => {
-  it('should init the GTM with the ID passed', async () => {
+  it('data layer appears before GTM snippet', async () => {
+    const params: ISnippetsParams = { id: 'GTM-test' }
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ id: 'GTM-test' }))
+    act(() => result.current.init({ ...params }))
 
-    expect(window.dataLayer).not.toBeUndefined()
+    const dataLayerNode = document.head.childNodes[0] as HTMLScriptElement
+    const gtmSnippetNode = document.head.childNodes[1] as HTMLScriptElement
+
+    expect(dataLayerNode?.textContent).toContain('dataLayer')
+    expect(gtmSnippetNode?.src).toContain('gtm')
+    expect(gtmSnippetNode?.src).toContain(params.id)
+  })
+
+  it('should init the GTM with the ID passed', async () => {
+    const params: ISnippetsParams = { id: 'GTM-test' }
+    const { result } = renderHook(() => useGTM())
+
+    act(() => result.current.init({ ...params }))
+
+    expect(window['dataLayer']).not.toBeUndefined()
   })
 
   it('should init the GTM with a custom data layer name', async () => {
     const params: ISnippetsParams = { id: 'GTM-test', dataLayerName: 'customDataLayerName' }
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ ...params }))
+    act(() => result.current.init({ ...params }))
 
     expect(window['customDataLayerName']).not.toBeUndefined()
   })
@@ -33,7 +48,7 @@ describe('Suite of useGTM Hook', () => {
     }
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ ...params }))
+    act(() => result.current.init({ ...params }))
 
     expect(window['myDataLayer']).not.toBeUndefined()
     expect(window['myDataLayer']).toContainEqual({ homepage: false, ecommerce: true })
@@ -49,7 +64,7 @@ describe('Suite of useGTM Hook', () => {
     }
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ ...params }))
+    act(() => result.current.init({ ...params }))
 
     expect(window['awesomeDataLayer']).not.toBeUndefined()
     expect(window['awesomeDataLayer']).toContainEqual({ homepage: false })
@@ -58,17 +73,17 @@ describe('Suite of useGTM Hook', () => {
   it('should send the data to the GTM', async () => {
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ id: 'GTM-test' }))
-    await act(async () => await result.current.sendDataToGTM({ event: 'works' }))
+    act(() => result.current.init({ id: 'GTM-test' }))
+    act(() => result.current.sendDataToGTM({ event: 'works' }))
 
-    expect(window.dataLayer).toContainEqual({ event: 'works' })
+    expect(window['dataLayer']).toContainEqual({ event: 'works' })
   })
 
   it('should send the data to the GTM with a custom dataLayer name', async () => {
     const { result } = renderHook(() => useGTM())
 
-    await act(async () => await result.current.init({ id: 'GTM-test', dataLayerName: 'customDL' }))
-    await act(async () => await result.current.sendDataToGTM({ event: 'works' }))
+    act(() => result.current.init({ id: 'GTM-test', dataLayerName: 'customDL' }))
+    act(() => result.current.sendDataToGTM({ event: 'works' }))
 
     expect(window['customDL']).toContainEqual({ event: 'works' })
   })


### PR DESCRIPTION
Add support to insert the `gtm_auth`, `gtm_preview` and `gtm_cookies_win` parameters to the GTM script request. This allows users to use GTM environments.

Also fixed some minor bugs and failing tests.

Resolves #2 
