### PR TITLE
Inject dataLayer before GTM script

### DIFF
--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -55,8 +55,8 @@ export const initGTM = ({ dataLayer, dataLayerName, environment, nonce, id }: IS
   const script = gtm.getScript()
   const noScript = gtm.getNoScript()
 
-  document.head.insertBefore(script, document.head.childNodes[0])
   document.head.insertBefore(dataLayerScript, document.head.childNodes[0])
+  document.head.insertBefore(script, document.head.childNodes[0])
   document.body.insertBefore(noScript, document.body.childNodes[0])
 }
 

--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -56,7 +56,7 @@ export const initGTM = ({ dataLayer, dataLayerName, environment, nonce, id }: IS
   const noScript = gtm.getNoScript()
 
   document.head.insertBefore(dataLayerScript, document.head.childNodes[0])
-  document.head.insertBefore(script, document.head.childNodes[0])
+  document.head.insertBefore(script, document.head.childNodes[1])
   document.body.insertBefore(noScript, document.body.childNodes[0])
 }
 


### PR DESCRIPTION
By injecting the GTM script before the dataLayer, the userId in the state doesn't work in Google Analytics, as it is initialized before the id is set.

This way it seems to work correctly.

Reference: [https://developers.google.com/tag-platform/tag-manager/web/datalayer#installation](https://developers.google.com/tag-platform/tag-manager/web/datalayer#installation)