### PR TITLE
feat (InjectScript): Provide way to conditionally inject script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ const MyAwesomeComp = () => {
 | dataLayer     | `Object` | **NO**   | Custom values for the dataLayer, like `{'my-init-prop': 'value'}`                   |
 | dataLayerName | `String` | **NO**   | Custom name for the dataLayer, if not passed, it will be the default: `dataLayer`   |
 | environment   | `Object` | **NO**   | Provide the `gtm_auth` and `gtm_preview` parameters to use a custom GTM environment |
-| nonce   | `String` | **NO**   | Server generated nonce. see https://developers.google.com/tag-manager/web/csp |
+| nonce         | `String` | **NO**   | Server generated nonce. see https://developers.google.com/tag-manager/web/csp |
+| injectScript  | `Boolean`| **NO**   | default(`true`): Decide if the GTM Script is injected, see #30. Also allows for delayed injection by toggling true later in flow |
 
 ### SentDataToGTM
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ declare global {
 /**
  * The shape of the context provider
  */
-type GTMHookProviderProps = { state?: any; children: ReactNode }
+type GTMHookProviderProps = { state?: ISnippetsParams; children: ReactNode }
 
 /**
  * The shape of the hook
@@ -31,7 +31,8 @@ export const initialState: ISnippetsParams = {
   dataLayerName: 'dataLayer',
   environment: undefined,
   nonce: undefined,
-  id: ''
+  id: '',
+  injectScript: true
 }
 
 /**
@@ -52,14 +53,17 @@ function GTMProvider({ state, children }: GTMHookProviderProps): JSX.Element {
   const [store, dispatch] = useReducer(dataReducer, { ...initialState, ...state })
 
   useEffect(() => {
+    if (!state || state.injectScript == false) 
+      return;
+    const mergedState = {...store, ...state};
     initGTM({
-      dataLayer: store.dataLayer,
-      dataLayerName: store.dataLayerName,
-      environment: store.environment,
-      nonce: store.nonce,
-      id: store.id
+      dataLayer: mergedState.dataLayer,
+      dataLayerName: mergedState.dataLayerName,
+      environment: mergedState.environment,
+      nonce: mergedState.nonce,
+      id: mergedState.id
     })
-  }, [store])
+  }, [JSON.stringify(state)])
 
   return (
     <GTMContext.Provider value={store}>

--- a/src/models/GoogleTagManager.ts
+++ b/src/models/GoogleTagManager.ts
@@ -37,8 +37,9 @@ export type ISnippetsParams = {
   dataLayer?: Pick<IDataLayer, 'dataLayer'>['dataLayer']
   dataLayerName?: Pick<IDataLayer, 'dataLayerName'>['dataLayerName']
   environment?: ICustomEnvironmentParams
-  nonce?: string;
-  id: string
+  nonce?: string,
+  id: string,
+  injectScript?: boolean
 }
 
 /**

--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -65,4 +65,10 @@ export const initGTM = ({ dataLayer, dataLayerName, environment, nonce, id }: IS
  * @param dataLayerName - The dataLayer name
  * @param data - The data to push
  */
-export const sendToGTM = ({ dataLayerName, data }: ISendToGTM): void => window[dataLayerName].push(data)
+export const sendToGTM = ({ dataLayerName, data }: ISendToGTM): void => {
+  if (window[dataLayerName]) {
+  window[dataLayerName].push(data);
+  } else {
+    console.warn(`dataLayer ${dataLayerName} does not exist, has script be initialized`);
+  }
+}


### PR DESCRIPTION
Introduce prop `injectScript: boolean`

* Provide way to conditionally inject script should help with #30 .  
* Provides the ability to delay script injection for cases such as not having the Id at time of render  GTMId (ie pulled in via REST) but still having the Provider Component rendered.
* SendToGTM will check for window.Datalayer or warn if not found, as it is not guaranteed now to have the script loaded.

The default value is true, to avoid changing existing API surface.