### PR TITLE
Don't push undefined datalayer during initialization

### DIFF
--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -9,7 +9,7 @@ export const getDataLayerSnippet = (
   dataLayer: Pick<IDataLayer, 'dataLayer'>['dataLayer'],
   dataLayerName: Pick<IDataLayer, 'dataLayerName'>['dataLayerName'] = 'dataLayer'
 ): Pick<ISnippets, 'gtmDataLayer'>['gtmDataLayer'] =>
-  `window.${dataLayerName} = window.${dataLayerName} || []; window.${dataLayerName}.push(${JSON.stringify(dataLayer)})`
+  `window.${dataLayerName} = window.${dataLayerName} || [];` + (dataLayer ? `window.${dataLayerName}.push(${JSON.stringify(dataLayer)})` : '')
 
 /**
  * Function to get the Iframe snippet


### PR DESCRIPTION
If in the state passed to the GTMProvider component the attribute dataLayer is not set, during the initialization an undefined item is pushed in the dataLayer.

I cannot find information regarding how bad it is to do this (GTM seems working without any problem), but surely it is useless and it causes some problems with some Chrome extensions, such as [Datalayer Checker](https://chrome.google.com/webstore/detail/datalayer-checker/ffljdddodmkedhkcjhpmdajhjdbkogke) and [Adswerve - dataLayer Inspector+
](https://chrome.google.com/webstore/detail/adswerve-datalayer-inspec/kmcbdogdandhihllalknlcjfpdjcleom).