### PR TITLE
fix: unable to use customDomain config

### DIFF
--- a/src/utils/GoogleTagManager.ts
+++ b/src/utils/GoogleTagManager.ts
@@ -9,7 +9,7 @@ const setupGTM = (params: ISnippetsParams): ISetupGTM => {
   const getDataLayerScript = (): HTMLElement => {
     const dataLayerScript = document.createElement('script')
     if (params.nonce) {
-      dataLayerScript.setAttribute("nonce", params.nonce);
+      dataLayerScript.setAttribute('nonce', params.nonce)
     }
     dataLayerScript.innerHTML = getDataLayerSnippet(params.dataLayer, params.dataLayerName)
     return dataLayerScript
@@ -17,16 +17,16 @@ const setupGTM = (params: ISnippetsParams): ISetupGTM => {
 
   const getNoScript = (): HTMLElement => {
     const noScript = document.createElement('noscript')
-    noScript.innerHTML = getIframeSnippet(params.id, params.environment)
+    noScript.innerHTML = getIframeSnippet(params.id, params.environment, params.customDomain)
     return noScript
   }
 
   const getScript = (): HTMLElement => {
     const script = document.createElement('script')
     if (params.nonce) {
-      script.setAttribute("nonce", params.nonce);
+      script.setAttribute('nonce', params.nonce)
     }
-    script.innerHTML = getGTMScript(params.dataLayerName, params.id, params.environment)
+    script.innerHTML = getGTMScript(params.dataLayerName, params.id, params.environment, params.customDomain)
     return script
   }
 
@@ -70,8 +70,8 @@ export const initGTM = ({ dataLayer, dataLayerName, environment, nonce, id }: IS
  */
 export const sendToGTM = ({ dataLayerName, data }: ISendToGTM): void => {
   if (window[dataLayerName]) {
-  window[dataLayerName].push(data);
+    window[dataLayerName].push(data)
   } else {
-    console.warn(`dataLayer ${dataLayerName} does not exist, has script be initialized`);
+    console.warn(`dataLayer ${dataLayerName} does not exist, has script be initialized`)
   }
 }


### PR DESCRIPTION
A follow up PR for this one https://github.com/elgorditosalsero/react-gtm-hook/pull/50

Currently we didn't pass the customDomain params so it doesn't work 😢 This PR passed down the customDomain, so we can use `customDomain` config 