### PR TITLE
Commit Message: Update GTMContextDispatch createContext type definition

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ export const initialState: ISnippetsParams = {
  * The context
  */
 export const GTMContext = createContext<ISnippetsParams | undefined>(initialState)
-export const GTMContextDispatch = createContext<any | undefined>(undefined)
+export const GTMContextDispatch = createContext<typeof sendToGTM | undefined>(undefined)
 
 function dataReducer(state: ISnippetsParams, data: any) {
   sendToGTM({ data, dataLayerName: state?.dataLayerName! })


### PR DESCRIPTION
### Summary
This commit updates the type definition for the GTMContextDispatch createContext to use the more specific typeof sendToGTM instead of any. This improves type safety and helps to catch any potential errors earlier in the development process.