### PR TITLE
I've tried to support multiple GTMs. Without breaking the existing interface, it can also be specified as an array.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ declare global {
 /**
  * The shape of the context provider
  */
-type GTMHookProviderProps = { states?: ISnippetsParams[]; children: ReactNode }
+type GTMHookProviderProps = { states?: ISnippetsParams | ISnippetsParams[]; children: ReactNode }
 
 /**
  * The shape of the hook
@@ -65,13 +65,21 @@ function GTMProvider({ states, children }: GTMHookProviderProps): JSX.Element {
   const [store, dispatch] = useReducer(dataReducer, [])
 
   useEffect(() => {
-    states?.forEach((state) => {
-      if (state.injectScript !== false) {
-        const mergedState = { ...initialState, ...state }
+    if (Array.isArray(states)) {
+      states?.forEach((state) => {
+        if (state.injectScript !== false) {
+          const mergedState = { ...initialState, ...state }
+          initGTM(mergedState)
+        }
+      })
+      dispatch({ type: 'ADD_STATE', states })
+    } else {
+      if (states?.injectScript !== false) {
+        const mergedState = { ...initialState, ...states }
         initGTM(mergedState)
+        dispatch({ type: 'ADD_STATE', states: [mergedState] })
       }
-    })
-    dispatch({ type: 'ADD_STATE', states: states })
+    }
   }, [states])
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ export const initialState: ISnippetsParams = {
  * The context
  */
 export const GTMContext = createContext<ISnippetsParams | undefined>(initialState)
-export const GTMContextDispatch = createContext<any | undefined>(undefined)
+export const GTMContextDispatch = createContext<typeof sendToGTM | undefined>(undefined)
 
 function dataReducer(state: ISnippetsParams, data: any) {
   sendToGTM({ data, dataLayerName: state?.dataLayerName! })


### PR DESCRIPTION
# Summary
Support for multiple GTMs by allowing `state` to be specified as an array as well

Fix https://github.com/elgorditosalsero/react-gtm-hook/issues/85

## Sample code
```ts
const param1 = {
  id: 'GTM-XXXXXXX',
  dataLayerName: 'dataLayerFirst',
}
const param2 = {
  id: 'GTM-XXXXXXX',
  dataLayerName: 'dataLayerSecond',
}
```

```tsx
<GTMProvider states={[param1, param2]}>
 <p>foo-bar</p>
</GTMProvider>
```

Or,


```tsx
<GTMProvider states={param1}>
 <p>foo-bar</p>
</GTMProvider>
```
